### PR TITLE
Added regex validation for evse_id

### DIFF
--- a/ocpi.cdrs.v22.ts
+++ b/ocpi.cdrs.v22.ts
@@ -45,7 +45,7 @@ export const CdrLocation = z.object({
     country: z.string().length(3),
     coordinates: GeoLocation,
     evse_uid: z.string().max(36),
-    evse_id: z.string().max(48),
+    evse_id: z.string().max(48).regex(/^(([A-Z]{2}\*?[A-Z0-9]{3}\*?E[A-Z0-9\*]{1,30})|(\+?[0-9]{1,3}\*[0-9]{3}\*[0-9\*]{1,32}))$/),
     connector_id: z.string().max(36),
     connector_standard: ConnectorType,
     connector_format: ConnectorFormat,

--- a/ocpi.cdrs.v221.ts
+++ b/ocpi.cdrs.v221.ts
@@ -48,7 +48,7 @@ export const CdrLocation = z.object({
     country: z.string().length(3),
     coordinates: GeoLocation,
     evse_uid: z.string().max(36),
-    evse_id: z.string().max(48),
+    evse_id: z.string().max(48).regex(/^(([A-Z]{2}\*?[A-Z0-9]{3}\*?E[A-Z0-9\*]{1,30})|(\+?[0-9]{1,3}\*[0-9]{3}\*[0-9\*]{1,32}))$/),
     connector_id: z.string().max(36),
     connector_standard: ConnectorType,
     connector_format: ConnectorFormat,

--- a/ocpi.location.ts
+++ b/ocpi.location.ts
@@ -85,7 +85,7 @@ const ParkingRestriction = z.enum([
 
 export const Evse = z.object({
   uid: z.string().max(39),
-  evse_id: z.string().max(48).nullish(),
+  evse_id: z.string().max(48).regex(/^(([A-Z]{2}\*?[A-Z0-9]{3}\*?E[A-Z0-9\*]{1,30})|(\+?[0-9]{1,3}\*[0-9]{3}\*[0-9\*]{1,32}))$/).nullish(),
   status: EvseStatus,
   status_schedule: z.array(StatusSchedule).nullish(),
   capabilities: z.array(Capability).nullish(),

--- a/ocpi.location.v22.ts
+++ b/ocpi.location.v22.ts
@@ -105,7 +105,7 @@ const ParkingRestriction = z.enum([
 
 export const Evse = z.object({
   uid: z.string().max(39),
-  evse_id: z.string().max(48).nullish(),
+  evse_id: z.string().max(48).regex(/^(([A-Z]{2}\*?[A-Z0-9]{3}\*?E[A-Z0-9\*]{1,30})|(\+?[0-9]{1,3}\*[0-9]{3}\*[0-9\*]{1,32}))$/).nullish(),
   status: EvseStatus,
   status_schedule: z.array(StatusSchedule).nullish(),
   capabilities: z.array(Capability).nullish(),

--- a/ocpi.location.v221.ts
+++ b/ocpi.location.v221.ts
@@ -125,7 +125,7 @@ const ParkingRestriction = z.enum([
 
 export const Evse = z.object({
   uid: z.string().max(39),
-  evse_id: z.string().max(48).nullish(),
+  evse_id: z.string().max(48).regex(/^(([A-Z]{2}\*?[A-Z0-9]{3}\*?E[A-Z0-9\*]{1,30})|(\+?[0-9]{1,3}\*[0-9]{3}\*[0-9\*]{1,32}))$/).nullish(),
   status: EvseStatus,
   status_schedule: z.array(StatusSchedule).nullish(),
   capabilities: z.array(Capability).nullish(),


### PR DESCRIPTION
This PR introduces a regular expression for validating `evse_id` values based on the format described in the eMI3 standard.

The eMI3 standard for EVSE IDs is described in chapter 1.3.2.1 of the following document:  
https://web.archive.org/web/20230327135510/https://emi3group.com/wp-content/uploads/sites/5/2018/12/eMI3-standard-v1.0-Part-2.pdf

The regular expression supports both ISO and DIN formats.  
More information can be found here:  
https://github.com/hubject/oicp/blob/master/OICP-2.3/OICP%202.3%20EMP/03_EMP_Data_Types.asciidoc#EvseIDType
